### PR TITLE
Add basic cash flow CLI app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # NineNine
+
+Aplicativo simples para gerenciamento de fluxo de caixa.
+
+## Uso
+
+Adicione receitas e despesas e veja o saldo atual.
+
+### Exemplos
+
+```bash
+python cash_flow.py add-income 100 "Venda"
+python cash_flow.py add-expense 50 "Compra de material"
+python cash_flow.py list
+```
+
+Os registros sao salvos no arquivo `transactions.json` no mesmo diretorio.

--- a/cash_flow.py
+++ b/cash_flow.py
@@ -1,0 +1,65 @@
+import argparse
+import json
+from datetime import date
+from pathlib import Path
+
+TRANSACTIONS_FILE = Path("transactions.json")
+
+def load_transactions():
+    if TRANSACTIONS_FILE.exists():
+        with open(TRANSACTIONS_FILE, "r") as f:
+            return json.load(f)
+    return []
+
+def save_transactions(transactions):
+    with open(TRANSACTIONS_FILE, "w") as f:
+        json.dump(transactions, f, indent=2)
+
+def add_transaction(amount, description):
+    transactions = load_transactions()
+    transactions.append({
+        "date": date.today().isoformat(),
+        "description": description,
+        "amount": amount
+    })
+    save_transactions(transactions)
+
+
+def balance():
+    transactions = load_transactions()
+    return sum(t["amount"] for t in transactions)
+
+
+def list_transactions():
+    transactions = load_transactions()
+    for t in transactions:
+        print(f"{t['date']} - {t['description']}: {t['amount']:.2f}")
+    print(f"Balance: {balance():.2f}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Nine Nine Cash Flow")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    income_parser = subparsers.add_parser("add-income", help="Add income transaction")
+    income_parser.add_argument("amount", type=float, help="Amount of income")
+    income_parser.add_argument("description", help="Description of income")
+
+    expense_parser = subparsers.add_parser("add-expense", help="Add expense transaction")
+    expense_parser.add_argument("amount", type=float, help="Amount of expense")
+    expense_parser.add_argument("description", help="Description of expense")
+
+    subparsers.add_parser("list", help="List transactions and balance")
+
+    args = parser.parse_args()
+
+    if args.command == "add-income":
+        add_transaction(abs(args.amount), args.description)
+    elif args.command == "add-expense":
+        add_transaction(-abs(args.amount), args.description)
+    elif args.command == "list":
+        list_transactions()
+
+
+if __name__ == "__main__":
+    main()

--- a/test_cash_flow.py
+++ b/test_cash_flow.py
@@ -1,0 +1,19 @@
+from cash_flow import TRANSACTIONS_FILE, add_transaction, balance, load_transactions
+from pathlib import Path
+import json
+import pytest
+
+
+def test_add_and_balance(tmp_path, monkeypatch):
+    temp_file = tmp_path / "transactions.json"
+    monkeypatch.setattr("cash_flow.TRANSACTIONS_FILE", temp_file)
+
+    add_transaction(200, "venda")
+    add_transaction(-50, "despesa")
+
+    assert temp_file.exists()
+    with open(temp_file) as f:
+        data = json.load(f)
+    assert len(data) == 2
+    assert balance() == 150
+


### PR DESCRIPTION
## Summary
- add a simple Python command line tool `cash_flow.py`
- create unit test for adding transactions and computing balance
- update README with usage instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685cc99bafbc832bac78e8e840b9dfcc